### PR TITLE
Expand multilingual docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+See the documentation in the `docs` directory for details about this project.
+- [English](docs/README_EN.md)
+- [中文](docs/README_ZH.md)
+- [日本語](docs/README_JP.md)

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -1,0 +1,51 @@
+# Muxkit Deep Learning Tools
+
+This repository provides reusable utilities for audio and vision research.
+
+## audio_tools
+
+### bc_augmentation
+- `mix_sounds(sound1, sound2, r, fs, device="cpu")` – mix two audio tensors with perceptual gain compensation.
+- `BCAugmentor(sample_rate)` – module wrapper exposing `.mix_sounds()`.
+- `BCLearningDataset(dataset, sample_rate, num_classes, device='cpu')` – dataset applying Between-Class augmentation.
+
+### transforms
+- `create_mask(size, mask_rate=0.5)` – generate a boolean mask tensor.
+- `tensor_masking(tensor, mask_rate=0.5, mask=None)` – return `(masked, unmasked, mask)`.
+- `TimeSequenceLengthFixer(fixed_length, sample_rate, mode="r")` – trim or pad audio to a fixed duration.
+- `SoundTrackSelector(mode)` – select left/right/mixed channel from stereo audio.
+- `TimeSequenceMaskingTransformer(mask_rate)` – time-domain masking module.
+- `SpectrogramMaskingTransformer(mask_rate)` – 2‑D spectrogram masking module.
+
+### utils
+- `fix_length(audio_data, sample_length)` – pad or crop audio to `sample_length` samples.
+
+## dataset_tools
+- `CacheableDataset(dataset, max_cache_size=1000, multiprocessing=False, device='cpu')` – cache dataset items in memory.
+- `label_digit2tensor(digits, class_num)` – convert label indices to a one-hot tensor.
+
+## lossfunction
+- `PLMLoss(label_distribution, lambda_rate=0.1, hist_bins=10, loss_kernel="bce")` – partial label masking loss. Call `update_ratios()` periodically.
+
+## model_tools
+- `freeze_module(module)` / `unfreeze_module(module)` – toggle gradient computation for all parameters.
+- `stati_model(model, unit='bytes')` – return parameter counts and approximate memory footprint.
+
+## plot_tools
+- `plot_confusion_matrix(matrix)` – draw a normalized confusion matrix with counts.
+- `ConfusionMatrixPlotter(class2label)` – `plot(confusion_matrix, n_rows=1, n_cols=1)` handles multi-class and multi-label matrices.
+
+## score_tools
+- `MonoLabelClassificationTester(model, device, loss_fn)` provides evaluation helpers:
+  - `set_dataloader(dataloader, n_class)`
+  - `predict_all()`
+  - `calculate_all_metrics()`
+  - `status_map()` → dictionary with F1, accuracy, precision and recall.
+
+## train_tools
+- `set_manual_seed(seed)` – set deterministic seeds for PyTorch, NumPy and Python random.
+
+## utl.api_tags
+Decorators to tag API status: `stable_api`, `deprecated`, `unfinished_api`, `untested`, `bug_api`.
+
+Unit tests live under each module's `unit_test` directory. Dependencies are declared in `pyproject.toml`.

--- a/docs/README_JP.md
+++ b/docs/README_JP.md
@@ -1,0 +1,51 @@
+# Muxkit ディープラーニングツール
+
+このリポジトリは、音声および画像研究で再利用できるユーティリティ群を提供します。
+
+## audio_tools
+
+### bc_augmentation
+- `mix_sounds(sound1, sound2, r, fs, device="cpu")`：二つの音声を知覚的なゲイン調整付きで混合します。
+- `BCAugmentor(sample_rate)`：`mix_sounds` をラップしたモジュールです。
+- `BCLearningDataset(dataset, sample_rate, num_classes, device='cpu')`：BC増強を適用するデータセット。
+
+### transforms
+- `create_mask(size, mask_rate=0.5)`：ブールマスクを生成します。
+- `tensor_masking(tensor, mask_rate=0.5, mask=None)`：`(masked, unmasked, mask)` を返します。
+- `TimeSequenceLengthFixer(fixed_length, sample_rate, mode="r")`：音声を指定時間に切り詰めまたはパディングします。
+- `SoundTrackSelector(mode)`：ステレオから左・右・ミックスを選択します。
+- `TimeSequenceMaskingTransformer(mask_rate)`：時系列マスキングのモジュール。
+- `SpectrogramMaskingTransformer(mask_rate)`：スペクトログラムを2次元でマスキングします。
+
+### utils
+- `fix_length(audio_data, sample_length)`：音声を指定サンプル数に調整します。
+
+## dataset_tools
+- `CacheableDataset(dataset, max_cache_size=1000, multiprocessing=False, device='cpu')`：データをメモリにキャッシュします。
+- `label_digit2tensor(digits, class_num)`：ラベルインデックスを one-hot テンソルに変換します。
+
+## lossfunction
+- `PLMLoss(label_distribution, lambda_rate=0.1, hist_bins=10, loss_kernel="bce")`：部分ラベルマスキング損失。定期的に `update_ratios()` を呼び出してください。
+
+## model_tools
+- `freeze_module(module)` / `unfreeze_module(module)`：モジュールのパラメータの勾配計算を切り替えます。
+- `stati_model(model, unit='bytes')`：パラメータ数とおおよそのメモリ使用量を返します。
+
+## plot_tools
+- `plot_confusion_matrix(matrix)`：正規化された混同行列を描画します。
+- `ConfusionMatrixPlotter(class2label)`：`plot(confusion_matrix, n_rows=1, n_cols=1)` で多クラス・多ラベルに対応。
+
+## score_tools
+- `MonoLabelClassificationTester(model, device, loss_fn)` により評価を行います：
+  - `set_dataloader(dataloader, n_class)`
+  - `predict_all()`
+  - `calculate_all_metrics()`
+  - `status_map()` で F1、Accuracy、Precision、Recall を取得。
+
+## train_tools
+- `set_manual_seed(seed)`：PyTorch、NumPy、Python の乱数シードを一括設定します。
+
+## utl.api_tags
+APIの状態を示すデコレータ：`stable_api`、`deprecated`、`unfinished_api`、`untested`、`bug_api`。
+
+各モジュールの `unit_test` ディレクトリにテストがあり、依存関係は `pyproject.toml` で管理されています。

--- a/docs/README_ZH.md
+++ b/docs/README_ZH.md
@@ -1,0 +1,51 @@
+# Muxkit 深度学习工具集
+
+该仓库提供在音频和视觉研究中可复用的工具代码。
+
+## audio_tools
+
+### bc_augmentation
+- `mix_sounds(sound1, sound2, r, fs, device="cpu")`：按感知增益混合两段音频。
+- `BCAugmentor(sample_rate)`：封装 `mix_sounds` 的模块。
+- `BCLearningDataset(dataset, sample_rate, num_classes, device='cpu')`：在数据集中应用 BC 增强。
+
+### transforms
+- `create_mask(size, mask_rate=0.5)`：生成布尔掩码张量。
+- `tensor_masking(tensor, mask_rate=0.5, mask=None)`：返回 `(masked, unmasked, mask)`。
+- `TimeSequenceLengthFixer(fixed_length, sample_rate, mode="r")`：将音频裁剪或填充到固定时长。
+- `SoundTrackSelector(mode)`：从立体声中选择左声道/右声道或混合通道。
+- `TimeSequenceMaskingTransformer(mask_rate)`：时域掩码模块。
+- `SpectrogramMaskingTransformer(mask_rate)`：二维谱图掩码模块。
+
+### utils
+- `fix_length(audio_data, sample_length)`：将音频补齐或截断到给定采样数。
+
+## dataset_tools
+- `CacheableDataset(dataset, max_cache_size=1000, multiprocessing=False, device='cpu')`：在内存中缓存数据样本。
+- `label_digit2tensor(digits, class_num)`：将标签索引列表转成 one-hot 张量。
+
+## lossfunction
+- `PLMLoss(label_distribution, lambda_rate=0.1, hist_bins=10, loss_kernel="bce")`：部分标签掩码损失，可定期调用 `update_ratios()` 更新比例。
+
+## model_tools
+- `freeze_module(module)` / `unfreeze_module(module)`：冻结或解冻模型参数。
+- `stati_model(model, unit='bytes')`：获取参数数量及大致占用内存。
+
+## plot_tools
+- `plot_confusion_matrix(matrix)`：绘制归一化并带计数的混淆矩阵。
+- `ConfusionMatrixPlotter(class2label)`：`plot(confusion_matrix, n_rows=1, n_cols=1)` 处理多类或多标签矩阵。
+
+## score_tools
+- `MonoLabelClassificationTester(model, device, loss_fn)` 提供评估流程：
+  - `set_dataloader(dataloader, n_class)`
+  - `predict_all()`
+  - `calculate_all_metrics()`
+  - `status_map()` 返回 F1、准确率、精确率和召回率。
+
+## train_tools
+- `set_manual_seed(seed)`：同时设置 PyTorch、NumPy 和随机库的种子。
+
+## utl.api_tags
+API 状态装饰器：`stable_api`、`deprecated`、`unfinished_api`、`untested`、`bug_api`。
+
+各模块在 `unit_test` 目录下提供测试示例，依赖项见 `pyproject.toml`。


### PR DESCRIPTION
## Summary
- provide detailed API descriptions in English, Chinese and Japanese docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*